### PR TITLE
Add jest setup and ProfileSidebar test

### DIFF
--- a/__tests__/ProfileSidebar.test.js
+++ b/__tests__/ProfileSidebar.test.js
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import ProfileSidebar from '../src/components/ProfileSidebar';
+
+test('renders github avatar with correct src', () => {
+  render(<ProfileSidebar githubUser="testuser" />);
+  const img = screen.getByRole('img');
+  expect(img).toHaveAttribute('src', 'https://github.com/testuser.png');
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect']
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "dependencies": {
     "jsonwebtoken": "^8.5.1",
@@ -18,7 +19,11 @@
   "devDependencies": {
     "@types/react": "^17.0.14",
     "babel-plugin-styled-components": "^1.12.0",
-    "datocms-client": "^3.4.11"
+    "datocms-client": "^3.4.11",
+    "jest": "^29.6.0",
+    "babel-jest": "^29.6.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add Jest configuration and testing libraries
- create ProfileSidebar test validating the avatar src
- add `test` script

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408d0808a4832b821b1edfaebc54e6