### PR TITLE
Fix comment in comunidades API

### DIFF
--- a/pages/api/comunidades.js
+++ b/pages/api/comunidades.js
@@ -7,7 +7,7 @@ export default async function RequestsHandler(request, response) {
         const client = new SiteClient(TOKEN);
     
         const record = await client.items.create({
-            itemType: '968553', // ID do Model de "Comunities" criado pelo Dato
+            itemType: '968553', // ID do Model de "Communities" criado pelo Dato
             ...request.body,
         })
 


### PR DESCRIPTION
## Summary
- correct spelling of "Communities" in `comunidades.js` comment

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408cfee058832b89816d5c42dfdf72