### PR TITLE
Fix z-index typo

### DIFF
--- a/src/components/ProfileRelations/index.js
+++ b/src/components/ProfileRelations/index.js
@@ -45,7 +45,7 @@ export const ProfileRelationsBoxWrapper = styled(Box)`
       right: 0;
       left: 0;
       bottom: 0;
-      z-indeX: 1;
+      z-index: 1;
       background-image: linear-gradient(0deg,#00000073,transparent);
     }
   }


### PR DESCRIPTION
## Summary
- fix z-index spelling in ProfileRelations component

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408cfd5740832b817e75b2afecf1a3