### PR TITLE
Fix variable name typo in index.js

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -56,8 +56,8 @@ export default function Home(props) {
       }` })
     })
     .then( async (response) => {
-      const responseComunities = await response.json();
-      setComunidades(responseComunities.data.allCommunities);
+      const responseCommunities = await response.json();
+      setComunidades(responseCommunities.data.allCommunities);
     })
   }, [])
 


### PR DESCRIPTION
## Summary
- fix typo in GraphQL response variable from `responseComunities` to `responseCommunities`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408cf593fc832ba045e91009da0eb8